### PR TITLE
hello-world: rename .DPR so doesn't appear as part of test suite

### DIFF
--- a/exercises/hello-world/HelloWorld.dpr
+++ b/exercises/hello-world/HelloWorld.dpr
@@ -1,4 +1,4 @@
-program TestHelloWorld;
+program HelloWorld;
 
 {$IFNDEF TESTINSIGHT}
 {$APPTYPE CONSOLE}


### PR DESCRIPTION
The DPR file is mostly just boiler plate for every exercise in the Delphi track.  No reason for the DPR to appear as part of the test suite on the main site.  It just needs to be included when the student fetches with CLI.