### PR TITLE
bob: rename DPR to remove test from name

### DIFF
--- a/exercises/bob/Bob.dpr
+++ b/exercises/bob/Bob.dpr
@@ -1,4 +1,4 @@
-program BobTests;
+program Bob;
 
 {$IFNDEF TESTINSIGHT}
 {$APPTYPE CONSOLE}


### PR DESCRIPTION
This will prevent the DPR from appearing as part of the test suite on the site to the student.  The file is still delivered when fetched with client.