### PR TITLE
readme.md: correct typos, add link to command line client

### DIFF
--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -1,8 +1,8 @@
 ## Running The Tests
 
-Exercises that have been fetched using the Exercism.io client are delivered with a minimum of three files: a `readme.md` file, a `.dpr` file, and a `.pas` file.  The `.dpr` file is the Delphi project file and the `.pas` file is the test runner.  Load the Delphi project by either double clicking on the `.dpr` file or by opening the project from with in Delphi.  You will be responsible for creating a new `.pas` file that will contain your solution code that the tests will be run against.  Refer to the `readme.md` file for instruction on how to compiles and execute your code.
+Exercises that have been fetched using the Exercism.io [command line client](http://www.exercism.io/cli) are delivered with a minimum of three files: a `readme.md` file, a `.dpr` file, and a `.pas` file.  The `.dpr` file is the Delphi project file and the `.pas` file is the test runner.  Load the Delphi project by either double clicking on the `.dpr` file or by opening the project from with in Delphi.  You will be responsible for creating a new `.pas` file that will contain your solution code that the tests will be run against.  Refer to the `readme.md` file for instruction on how to compile and execute your code.
 
-All tests have been ignored except the first one for you to work on. To continue, just comment the ```[Ignore]``` attribute on the test to start working on it.
+All tests have been ignored except the first one for you to work on. To continue, just comment the `[Ignore]` attribute on the test to start working on it.
 
 Make sure [DUnitX](https://github.com/VSoftTechnologies/DUnitX) is installed, if not already installed from the setup above.
 


### PR DESCRIPTION
Fixed an instance of bad spelling.  Added a link to the command line client download page.