### PR TITLE
Add exercise two-fer

### DIFF
--- a/config.json
+++ b/config.json
@@ -8,6 +8,13 @@
 	  "slug": "hello-world",
 	  "difficulty": 1,
 	  "topics": [
+	    "Text formatting"
+	  ]
+	},
+    {
+	  "slug": "two-fer",
+	  "difficulty": 1,
+	  "topics": [
 	    "Text formatting",
 	    "Optional values"
 	  ]

--- a/exercises/two-fer/twofer.dpr
+++ b/exercises/two-fer/twofer.dpr
@@ -1,0 +1,60 @@
+program twofer;
+
+{$IFNDEF TESTINSIGHT}
+{$APPTYPE CONSOLE}
+{$ENDIF}{$STRONGLINKTYPES ON}
+uses
+  System.SysUtils,
+  {$IFDEF TESTINSIGHT}
+  TestInsight.DUnitX,
+  {$ENDIF }
+  DUnitX.Loggers.Console,
+  DUnitX.Loggers.Xml.NUnit,
+  DUnitX.TestFramework,
+  utwoferTest in 'utwoferTest.pas',
+  utwofer in 'utwofer.pas';
+
+var
+  runner : ITestRunner;
+  results : IRunResults;
+  logger : ITestLogger;
+  nunitLogger : ITestLogger;
+begin
+{$IFDEF TESTINSIGHT}
+  TestInsight.DUnitX.RunRegisteredTests;
+  exit;
+{$ENDIF}
+  try
+    //Check command line options, will exit if invalid
+    TDUnitX.CheckCommandLine;
+    //Create the test runner
+    runner := TDUnitX.CreateRunner;
+    //Tell the runner to use RTTI to find Fixtures
+    runner.UseRTTI := True;
+    //tell the runner how we will log things
+    //Log to the console window
+    logger := TDUnitXConsoleLogger.Create(true);
+    runner.AddLogger(logger);
+    //Generate an NUnit compatible XML File
+    nunitLogger := TDUnitXXMLNUnitFileLogger.Create(TDUnitX.Options.XMLOutputFile);
+    runner.AddLogger(nunitLogger);
+    runner.FailsOnNoAsserts := False; //When true, Assertions must be made during tests;
+
+    //Run tests
+    results := runner.Execute;
+    if not results.AllPassed then
+      System.ExitCode := EXIT_ERRORS;
+
+    {$IFNDEF CI}
+    //We don't want this happening when running under CI.
+    if TDUnitX.Options.ExitBehavior = TDUnitXExitBehavior.Pause then
+    begin
+      System.Write('Done.. press <Enter> key to quit.');
+      System.Readln;
+    end;
+    {$ENDIF}
+  except
+    on E: Exception do
+      System.Writeln(E.ClassName, ': ', E.Message);
+  end;
+end.

--- a/exercises/two-fer/utwoferExample.pas
+++ b/exercises/two-fer/utwoferExample.pas
@@ -1,0 +1,17 @@
+unit utwofer;
+
+interface
+
+  function twoFer(aName: string=''): string;
+
+implementation
+uses SysUtils;
+
+function twoFer(aName: string=''): string;
+begin
+  if trim(aName).IsEmpty then
+    aName := 'you';
+  result := 'One for ' + aName + ', one for me.';
+end;
+
+end.

--- a/exercises/two-fer/utwoferTest.pas
+++ b/exercises/two-fer/utwoferTest.pas
@@ -1,0 +1,71 @@
+(******************************************************************************
+ You got an error, which is exactly as it should be.
+ This is the first step in the Test-Driven Development
+ (TDD) process.
+
+ The most important part of the error is
+
+   "cannot compile"
+
+ It's looking for a file named utwo-fer.pas that doesn't exist.
+
+ To fix the error, create a unit file named utwo-fer.pas
+ in the same directory as the file utwo-ferTest.pas.
+
+ The beginning of the new unit file should contain a unit statement:
+
+ unit utwo-fer;
+
+ The new unit should contain Interface, Implementation, and End. statements.
+
+ Hint: Delphi will take care of all this if you instruct it to add a new unit
+ to your project.  Be sure to save the new unit as utwo-fer.pas before
+ trying to compile again.
+
+ For more guidance as you work on this exercise, see
+ GETTING_STARTED.md.
+******************************************************************************)
+unit utwoferTest;
+
+interface
+uses
+  DUnitX.TestFramework;
+
+type
+  [TestFixture]
+  twoferTest = class(TObject)
+  public
+    [Test]
+//    [Ignore('Comment the "[Ignore]" statement to run the test')]
+    procedure No_name_given;
+
+    [Test]
+    [Ignore]
+    procedure A_name_given;
+
+    [Test]
+    [Ignore]
+    procedure Another_name_given;
+  end;
+
+implementation
+uses utwofer;
+
+procedure twoferTest.No_name_given;
+begin
+  Assert.AreEqual('One for you, one for me.', twoFer);
+end;
+
+procedure twoferTest.A_name_given;
+begin
+  Assert.AreEqual('One for Alice, one for me.', twoFer('Alice'));
+end;
+
+procedure twoferTest.Another_name_given;
+begin
+  Assert.AreEqual('One for Bob, one for me.', twoFer('Bob'));
+end;
+
+initialization
+  TDUnitX.RegisterTestFixture(twoferTest);
+end.


### PR DESCRIPTION
A new exercise that has been designed as a replacement to the original hello-world exercise.  Two-fer is intended to be a follow on exercise to the new hello-world exercise.