### PR TITLE
setup.md: grammar improvement

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -1,7 +1,7 @@
 ## Testing
 
 In order to run the tests for this track, you will need to install
-DUnitX. Please see [installation](http://www.exercism.io/languages/delphi/installing) instructions for more information.
+DUnitX. Please see the [installation](http://www.exercism.io/languages/delphi/installing) instructions for more information.
 
 ### Loading Exercises into Delphi
 


### PR DESCRIPTION
The sentence needed a 'the'.